### PR TITLE
Implement memory scanning and build script

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.15)
+project(CS2AntiCheat LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_AUTORCC ON)
+set(CMAKE_AUTOUIC OFF)
+
+find_package(Qt6 REQUIRED COMPONENTS Widgets)
+
+qt6_wrap_ui(UIS rc_mainwindow ui/mainwindow.ui)
+qt6_add_resources(RCS resources.qrc)
+
+add_executable(${PROJECT_NAME}
+    ${UIS}
+    ${RCS}
+    src/main.cpp
+    src/mainwindow.cpp
+    src/processscanner.cpp
+    src/filescanner.cpp
+    src/memoryscanner.cpp
+)
+
+target_include_directories(${PROJECT_NAME} PRIVATE src)
+
+target_link_libraries(${PROJECT_NAME} PRIVATE Qt6::Widgets)
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
-# anticheatcs2
+# CS2 Anti-Cheat
+
+This project provides a simple Qt-based Windows application that scans for known Counter-Strike 2 cheats. The application checks running processes, files on local drives and searches memory of the game process for cheat patterns.
+
+## Build
+
+Windows build requires Qt 6 and CMake 3.15 or newer. Use the provided `build.bat` script to generate Visual Studio files and compile the release build:
+
+```bat
+build.bat
+```
+
+`CS2AntiCheat.exe` will be copied to the project root on success.
+

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,10 @@
+@echo off
+REM Build CS2AntiCheat.exe via CMake and Visual Studio 2022 x64
+if not exist build mkdir build
+cd build
+cmake -G "Visual Studio 17 2022" -A x64 ..
+cmake --build . --config Release
+copy "Release\CS2AntiCheat.exe" "..\CS2AntiCheat.exe"
+echo Build complete: CS2AntiCheat.exe created in project root.
+pause
+

--- a/config/signatures.json
+++ b/config/signatures.json
@@ -1,0 +1,24 @@
+{
+  "process_names": [
+    "cheatengine.exe", "aimbot.exe", "cs2hack.exe", "wallhack.exe",
+    "iniuria.exe", "aimware.dll", "neverlose.dll", "neverlose.exe",
+    "gamesense cracked.exe", "fecurity.exe", "primordial.dll",
+    "midnight.exe", "interwebz.exe", "otv3.dll", "onetap.dll",
+    "nixware.dll", "fatality.exe", "plague.dll", "oxide.exe",
+    "fantasy.exe", "phantomoverlayloader.exe", "clutch.exe",
+    "nightfall.exe", "kernaim.exe", "satan5.exe", "cartel.exe",
+    "scriptersrift.dll", "memesense.dll"
+  ],
+  "file_hashes": {
+    "d41d8cd98f00b204e9800998ecf8427e": "ExampleCheat",
+    "6e3293bb4d8fbb87f9485da9875aee45": "Primordial",
+    "d6f07b2df0bd08aeca44b6aa714a3f6b": "Fecurity",
+    "4e5bcdd4a99b77c6e5cde337508c2019": "Primordial_DLL",
+    "d2901c7724d3a55d168f10f21b9e7393": "CS2-Cheats.pro_v2.3",
+    "a9d7c3f8b8b82e01f9e56c3d4ca1cc10": "AimbotPro",
+    "0e339b253f3d32c0d3af65bb9a9853d8": "WallHackX"
+  },
+  "memory_signatures": {
+    "666f6f626172": "ExampleMemoryCheat"
+  }
+}

--- a/resources.qrc
+++ b/resources.qrc
@@ -1,0 +1,4 @@
+<RCC>
+  <qresource prefix="/icons">
+  </qresource>
+</RCC>

--- a/src/filescanner.cpp
+++ b/src/filescanner.cpp
@@ -1,0 +1,131 @@
+#include "filescanner.h"
+
+#include <Windows.h>
+#include <wincrypt.h>
+#include <filesystem>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+
+#pragma comment(lib, "Advapi32.lib")
+
+FileScanner::FileScanner(QObject *parent)
+    : QThread(parent)
+{
+    loadSignatures();
+}
+
+void FileScanner::requestStop()
+{
+    m_stopRequested = true;
+}
+
+void FileScanner::loadSignatures()
+{
+    QFile f("config/signatures.json");
+    if (!f.open(QIODevice::ReadOnly))
+        return;
+    QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+    f.close();
+    if (doc.isObject()) {
+        QJsonObject obj = doc.object();
+        QJsonObject hashes = obj.value("file_hashes").toObject();
+        for (auto it = hashes.begin(); it != hashes.end(); ++it) {
+            m_signatures.insert(it.key().toLower(), it.value().toString());
+        }
+    }
+}
+
+QString FileScanner::hashFileMd5(const std::wstring &path)
+{
+    HCRYPTPROV hProv = 0;
+    HCRYPTHASH hHash = 0;
+    if (!CryptAcquireContextW(&hProv, nullptr, nullptr, PROV_RSA_FULL, CRYPT_VERIFYCONTEXT))
+        return {};
+    if (!CryptCreateHash(hProv, CALG_MD5, 0, 0, &hHash)) {
+        CryptReleaseContext(hProv, 0);
+        return {};
+    }
+
+    HANDLE hFile = CreateFileW(path.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr, OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, nullptr);
+    if (hFile == INVALID_HANDLE_VALUE) {
+        CryptDestroyHash(hHash);
+        CryptReleaseContext(hProv, 0);
+        return {};
+    }
+
+    const DWORD bufSize = 8192;
+    BYTE buffer[bufSize];
+    DWORD bytesRead = 0;
+    while (ReadFile(hFile, buffer, bufSize, &bytesRead, nullptr) && bytesRead) {
+        CryptHashData(hHash, buffer, bytesRead, 0);
+    }
+    CloseHandle(hFile);
+
+    BYTE hash[16];
+    DWORD hashSize = sizeof(hash);
+    CryptGetHashParam(hHash, HP_HASHVAL, hash, &hashSize, 0);
+
+    CryptDestroyHash(hHash);
+    CryptReleaseContext(hProv, 0);
+
+    QString hex;
+    for (DWORD i = 0; i < hashSize; ++i) {
+        hex += QString::asprintf("%02x", hash[i]);
+    }
+    return hex.toLower();
+}
+
+void FileScanner::run()
+{
+    quint64 filesScanned = 0;
+    quint64 totalFiles = 0;
+    DWORD mask = GetLogicalDrives();
+
+    std::vector<std::wstring> roots;
+    for (int i = 0; i < 26; ++i) {
+        if (mask & (1 << i)) {
+            wchar_t drive[] = { static_cast<wchar_t>('A' + i), L':', L'\\', 0 };
+            roots.emplace_back(drive);
+        }
+    }
+
+    for (const auto &root : roots) {
+        for (auto it = std::filesystem::recursive_directory_iterator(root, std::filesystem::directory_options::skip_permission_denied);
+             it != std::filesystem::recursive_directory_iterator(); ++it) {
+            if (m_stopRequested) {
+                emit scanFinished();
+                return;
+            }
+            if (it->is_regular_file())
+                ++totalFiles;
+        }
+    }
+
+    for (const auto &root : roots) {
+        for (auto it = std::filesystem::recursive_directory_iterator(root, std::filesystem::directory_options::skip_permission_denied);
+             it != std::filesystem::recursive_directory_iterator(); ++it) {
+            if (m_stopRequested) {
+                emit scanFinished();
+                return;
+            }
+            if (!it->is_regular_file())
+                continue;
+
+            std::wstring wpath = it->path().wstring();
+            QString md5 = hashFileMd5(wpath);
+            if (m_signatures.contains(md5)) {
+                emit fileFound(QString::fromStdWString(wpath), m_signatures.value(md5));
+            }
+
+            ++filesScanned;
+            if (filesScanned % 100 == 0) {
+                emit progressUpdated(filesScanned, totalFiles);
+            }
+        }
+    }
+
+    emit progressUpdated(filesScanned, totalFiles);
+    emit scanFinished();
+}

--- a/src/filescanner.h
+++ b/src/filescanner.h
@@ -1,0 +1,33 @@
+#ifndef FILESCANNER_H
+#define FILESCANNER_H
+
+#include <QThread>
+#include <QHash>
+#include <atomic>
+
+class FileScanner : public QThread
+{
+    Q_OBJECT
+public:
+    explicit FileScanner(QObject *parent = nullptr);
+
+    void requestStop();
+
+protected:
+    void run() override;
+
+private:
+    void loadSignatures();
+    QString hashFileMd5(const std::wstring &path);
+
+signals:
+    void fileFound(QString filePath, QString cheatName);
+    void progressUpdated(quint64 scanned, quint64 total);
+    void scanFinished();
+
+private:
+    QHash<QString, QString> m_signatures;
+    std::atomic_bool m_stopRequested{false};
+};
+
+#endif // FILESCANNER_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,10 @@
+#include <QApplication>
+#include "mainwindow.h"
+
+int main(int argc, char *argv[])
+{
+    QApplication app(argc, argv);
+    MainWindow w;
+    w.show();
+    return app.exec();
+}

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -1,0 +1,202 @@
+#include "mainwindow.h"
+#include "processscanner.h"
+#include "filescanner.h"
+#include "memoryscanner.h"
+
+#include <QPushButton>
+#include <QProgressBar>
+#include <QTableWidget>
+#include <QVBoxLayout>
+#include <QMessageBox>
+
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+
+MainWindow::MainWindow(QWidget *parent)
+    : QMainWindow(parent)
+{
+    setWindowTitle("CS2 Anti-Cheat");
+
+    QWidget *central = new QWidget(this);
+    setCentralWidget(central);
+
+    QVBoxLayout *layout = new QVBoxLayout(central);
+    QTabWidget *tabWidget = new QTabWidget(central);
+    layout->addWidget(tabWidget);
+
+    QWidget *tabOverview = new QWidget();
+    tabWidget->addTab(tabOverview, tr("Overview"));
+
+    QWidget *tabFile = new QWidget();
+    QVBoxLayout *fileLayout = new QVBoxLayout(tabFile);
+    QPushButton *scanFilesButton = new QPushButton(tr("Сканировать файлы"));
+    scanFilesButton->setObjectName("scanFilesButton");
+    fileLayout->addWidget(scanFilesButton);
+    QProgressBar *fileProgress = new QProgressBar();
+    fileProgress->setObjectName("fileProgressBar");
+    fileLayout->addWidget(fileProgress);
+    QPushButton *cancelFileButton = new QPushButton(tr("Отмена"));
+    cancelFileButton->setObjectName("cancelFileScanButton");
+    fileLayout->addWidget(cancelFileButton);
+    QTableWidget *tableFiles = new QTableWidget();
+    tableFiles->setObjectName("tableFiles");
+    tableFiles->setColumnCount(2);
+    tableFiles->setHorizontalHeaderLabels({tr("Путь"), tr("Название чита")});
+    fileLayout->addWidget(tableFiles);
+    tabWidget->addTab(tabFile, tr("File Scan"));
+
+    QWidget *tabProcesses = new QWidget();
+    QVBoxLayout *procLayout = new QVBoxLayout(tabProcesses);
+    QPushButton *scanProcessesButton = new QPushButton(tr("Сканировать процессы"));
+    scanProcessesButton->setObjectName("scanProcessesButton");
+    procLayout->addWidget(scanProcessesButton);
+    QTableWidget *tableProcesses = new QTableWidget();
+    tableProcesses->setObjectName("tableProcesses");
+    tableProcesses->setColumnCount(2);
+    tableProcesses->setHorizontalHeaderLabels({tr("PID"), tr("Имя процесса")});
+    procLayout->addWidget(tableProcesses);
+    tabWidget->addTab(tabProcesses, tr("Process Scan"));
+
+    QWidget *tabMemory = new QWidget();
+    QVBoxLayout *memLayout = new QVBoxLayout(tabMemory);
+    QPushButton *scanMemoryButton = new QPushButton(tr("Сканировать память"));
+    scanMemoryButton->setObjectName("scanMemoryButton");
+    memLayout->addWidget(scanMemoryButton);
+    QTableWidget *tableMemory = new QTableWidget();
+    tableMemory->setObjectName("tableMemory");
+    tableMemory->setColumnCount(2);
+    tableMemory->setHorizontalHeaderLabels({tr("Адрес"), tr("Название чита")});
+    memLayout->addWidget(tableMemory);
+    tabWidget->addTab(tabMemory, tr("Memory Scan"));
+
+    QWidget *tabSettings = new QWidget();
+    tabWidget->addTab(tabSettings, tr("Settings"));
+
+    connect(scanProcessesButton, &QPushButton::clicked, this, &MainWindow::onScanProcesses);
+    connect(scanFilesButton, &QPushButton::clicked, this, &MainWindow::onStartFileScan);
+    connect(cancelFileButton, &QPushButton::clicked, this, &MainWindow::onCancelFileScan);
+    connect(scanMemoryButton, &QPushButton::clicked, this, &MainWindow::onStartMemoryScan);
+}
+
+MainWindow::~MainWindow()
+{
+}
+
+void MainWindow::onScanProcesses()
+{
+    if (processScanner) {
+        return;
+    }
+    processScanner = new ProcessScanner(this);
+    connect(processScanner, &ProcessScanner::processFound, this, &MainWindow::onProcessFound);
+    connect(processScanner, &ProcessScanner::scanFinished, this, &MainWindow::onProcessScanFinished);
+    connect(processScanner, &QThread::finished, processScanner, &QObject::deleteLater);
+    processScanner->start();
+}
+
+void MainWindow::onProcessFound(qint64 pid, QString name)
+{
+    QTableWidget *table = findChild<QTableWidget*>("tableProcesses");
+    if (!table)
+        return;
+    int row = table->rowCount();
+    table->insertRow(row);
+    table->setItem(row, 0, new QTableWidgetItem(QString::number(pid)));
+    table->setItem(row, 1, new QTableWidgetItem(name));
+}
+
+void MainWindow::onProcessScanFinished()
+{
+    processScanner = nullptr;
+}
+
+void MainWindow::onStartFileScan()
+{
+    if (fileScanner)
+        return;
+    fileScanner = new FileScanner(this);
+    connect(fileScanner, &FileScanner::fileFound, this, &MainWindow::onFileFound);
+    connect(fileScanner, &FileScanner::progressUpdated, this, &MainWindow::onFileScanProgress);
+    connect(fileScanner, &FileScanner::scanFinished, this, &MainWindow::onFileScanFinished);
+    connect(fileScanner, &QThread::finished, fileScanner, &QObject::deleteLater);
+    fileScanner->start();
+}
+
+void MainWindow::onFileFound(QString path, QString cheatName)
+{
+    QTableWidget *table = findChild<QTableWidget*>("tableFiles");
+    if (!table)
+        return;
+    int row = table->rowCount();
+    table->insertRow(row);
+    table->setItem(row, 0, new QTableWidgetItem(path));
+    table->setItem(row, 1, new QTableWidgetItem(cheatName));
+}
+
+void MainWindow::onFileScanProgress(quint64 done, quint64 total)
+{
+    QProgressBar *bar = findChild<QProgressBar*>("fileProgressBar");
+    if (!bar)
+        return;
+    bar->setMaximum(static_cast<int>(total));
+    bar->setValue(static_cast<int>(done));
+}
+
+void MainWindow::onFileScanFinished()
+{
+    fileScanner = nullptr;
+}
+
+void MainWindow::onCancelFileScan()
+{
+    if (fileScanner)
+        fileScanner->requestStop();
+}
+
+void MainWindow::onStartMemoryScan()
+{
+    if (memoryScanner)
+        return;
+    memoryScanner = new MemoryScanner(this);
+    connect(memoryScanner, &MemoryScanner::signatureFound, this, &MainWindow::onMemoryPatternFound);
+    connect(memoryScanner, &MemoryScanner::scanFinished, this, &MainWindow::onMemoryScanFinished);
+    connect(memoryScanner, &QThread::finished, memoryScanner, &QObject::deleteLater);
+    memoryScanner->start();
+}
+
+void MainWindow::onMemoryPatternFound(QString name, quint64 address)
+{
+    QTableWidget *table = findChild<QTableWidget*>("tableMemory");
+    if (!table)
+        return;
+    int row = table->rowCount();
+    table->insertRow(row);
+    table->setItem(row, 0, new QTableWidgetItem(QString("0x%1").arg(address, 0, 16)));
+    table->setItem(row, 1, new QTableWidgetItem(name));
+}
+
+void MainWindow::onMemoryScanFinished()
+{
+    memoryScanner = nullptr;
+}
+
+void MainWindow::onDeleteSelectedFile()
+{
+    QTableWidget *table = findChild<QTableWidget*>("tableFiles");
+    if (!table)
+        return;
+    auto items = table->selectedItems();
+    QSet<int> rows;
+    for (auto *item : items) {
+        rows.insert(item->row());
+    }
+    QList<int> rowList = rows.values();
+    std::sort(rowList.begin(), rowList.end(), std::greater<int>());
+    for (int row : rowList) {
+        QString path = table->item(row, 0)->text();
+        QFile::remove(path);
+        table->removeRow(row);
+    }
+}

--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -1,0 +1,40 @@
+#ifndef MAINWINDOW_H
+#define MAINWINDOW_H
+
+#include <QMainWindow>
+#include <QThread>
+
+class ProcessScanner;
+class FileScanner;
+class MemoryScanner;
+
+class MainWindow : public QMainWindow
+{
+    Q_OBJECT
+public:
+    explicit MainWindow(QWidget *parent = nullptr);
+    ~MainWindow();
+
+private slots:
+    void onScanProcesses();
+    void onProcessFound(qint64 pid, QString name);
+    void onProcessScanFinished();
+
+    void onStartFileScan();
+    void onFileFound(QString path, QString cheatName);
+    void onFileScanProgress(quint64 done, quint64 total);
+    void onFileScanFinished();
+    void onCancelFileScan();
+
+    void onStartMemoryScan();
+    void onMemoryPatternFound(QString name, quint64 address);
+    void onMemoryScanFinished();
+    void onDeleteSelectedFile();
+
+private:
+    ProcessScanner *processScanner = nullptr;
+    FileScanner *fileScanner = nullptr;
+    MemoryScanner *memoryScanner = nullptr;
+};
+
+#endif // MAINWINDOW_H

--- a/src/memoryscanner.cpp
+++ b/src/memoryscanner.cpp
@@ -1,0 +1,107 @@
+#include "memoryscanner.h"
+
+MemoryScanner::MemoryScanner(QObject *parent)
+    : QThread(parent)
+{
+}
+
+#include <Windows.h>
+#include <TlHelp32.h>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+
+struct MemSignature {
+    QByteArray pattern;
+    QString name;
+};
+
+static bool searchBytes(const QByteArray &data, const QByteArray &pattern, quint64 &offset)
+{
+    int idx = data.indexOf(pattern);
+    if (idx >= 0) {
+        offset = static_cast<quint64>(idx);
+        return true;
+    }
+    return false;
+}
+
+void MemoryScanner::run()
+{
+    QFile f("config/signatures.json");
+    if (!f.open(QIODevice::ReadOnly)) {
+        emit scanFinished();
+        return;
+    }
+    QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+    f.close();
+
+    std::vector<MemSignature> sigs;
+    if (doc.isObject()) {
+        QJsonObject memObj = doc.object().value("memory_signatures").toObject();
+        for (auto it = memObj.begin(); it != memObj.end(); ++it) {
+            MemSignature s{ QByteArray::fromHex(it.key().toUtf8()), it.value().toString() };
+            sigs.push_back(std::move(s));
+        }
+    }
+
+    if (sigs.empty()) {
+        emit scanFinished();
+        return;
+    }
+
+    DWORD pid = 0;
+    HANDLE snap = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (snap != INVALID_HANDLE_VALUE) {
+        PROCESSENTRY32W pe{ sizeof(pe) };
+        if (Process32FirstW(snap, &pe)) {
+            do {
+                QString exe = QString::fromWCharArray(pe.szExeFile).toLower();
+                if (exe == "cs2.exe") {
+                    pid = pe.th32ProcessID;
+                    break;
+                }
+            } while (Process32NextW(snap, &pe));
+        }
+        CloseHandle(snap);
+    }
+
+    if (!pid) {
+        emit scanFinished();
+        return;
+    }
+
+    HANDLE hProc = OpenProcess(PROCESS_VM_READ | PROCESS_QUERY_INFORMATION, FALSE, pid);
+    if (!hProc) {
+        emit scanFinished();
+        return;
+    }
+
+    SYSTEM_INFO sys;
+    GetSystemInfo(&sys);
+    quint64 addr = reinterpret_cast<quint64>(sys.lpMinimumApplicationAddress);
+    quint64 maxAddr = reinterpret_cast<quint64>(sys.lpMaximumApplicationAddress);
+    MEMORY_BASIC_INFORMATION mbi;
+    QByteArray buffer;
+    while (addr < maxAddr) {
+        if (VirtualQueryEx(hProc, reinterpret_cast<LPCVOID>(addr), &mbi, sizeof(mbi)) != sizeof(mbi))
+            break;
+        if (mbi.State == MEM_COMMIT && !(mbi.Protect & PAGE_GUARD) && (mbi.Protect & (PAGE_READWRITE|PAGE_EXECUTE_READ|PAGE_EXECUTE_READWRITE|PAGE_EXECUTE_WRITECOPY))) {
+            buffer.resize(mbi.RegionSize);
+            SIZE_T read = 0;
+            if (ReadProcessMemory(hProc, mbi.BaseAddress, buffer.data(), mbi.RegionSize, &read) && read > 0) {
+                QByteArray data = QByteArray::fromRawData(buffer.data(), static_cast<int>(read));
+                for (const MemSignature &s : sigs) {
+                    quint64 off;
+                    if (searchBytes(data, s.pattern, off)) {
+                        emit signatureFound(s.name, addr + off);
+                    }
+                }
+            }
+        }
+        addr = reinterpret_cast<quint64>(mbi.BaseAddress) + mbi.RegionSize;
+    }
+
+    CloseHandle(hProc);
+    emit scanFinished();
+}

--- a/src/memoryscanner.h
+++ b/src/memoryscanner.h
@@ -1,0 +1,20 @@
+#ifndef MEMORYSCANNER_H
+#define MEMORYSCANNER_H
+
+#include <QThread>
+
+class MemoryScanner : public QThread
+{
+    Q_OBJECT
+public:
+    explicit MemoryScanner(QObject *parent = nullptr);
+
+protected:
+    void run() override;
+
+signals:
+    void signatureFound(QString name, quint64 address);
+    void scanFinished();
+};
+
+#endif // MEMORYSCANNER_H

--- a/src/processscanner.cpp
+++ b/src/processscanner.cpp
@@ -1,0 +1,52 @@
+#include "processscanner.h"
+
+#include <Windows.h>
+#include <TlHelp32.h>
+#include <QFile>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
+
+ProcessScanner::ProcessScanner(QObject *parent)
+    : QThread(parent)
+{
+}
+
+void ProcessScanner::run()
+{
+    QFile f("config/signatures.json");
+    if (!f.open(QIODevice::ReadOnly)) {
+        emit scanFinished();
+        return;
+    }
+    QJsonDocument doc = QJsonDocument::fromJson(f.readAll());
+    f.close();
+    QStringList names;
+    if (doc.isObject()) {
+        QJsonObject obj = doc.object();
+        QJsonArray arr = obj.value("process_names").toArray();
+        for (const QJsonValue &v : arr) {
+            names.append(v.toString().toLower());
+        }
+    }
+
+    HANDLE hSnapshot = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
+    if (hSnapshot == INVALID_HANDLE_VALUE) {
+        emit scanFinished();
+        return;
+    }
+
+    PROCESSENTRY32W pe;
+    pe.dwSize = sizeof(pe);
+    if (Process32FirstW(hSnapshot, &pe)) {
+        do {
+            QString exe = QString::fromWCharArray(pe.szExeFile).toLower();
+            if (names.contains(exe)) {
+                emit processFound(static_cast<qint64>(pe.th32ProcessID), exe);
+            }
+        } while (Process32NextW(hSnapshot, &pe));
+    }
+    CloseHandle(hSnapshot);
+
+    emit scanFinished();
+}

--- a/src/processscanner.h
+++ b/src/processscanner.h
@@ -1,0 +1,20 @@
+#ifndef PROCESSSCANNER_H
+#define PROCESSSCANNER_H
+
+#include <QThread>
+
+class ProcessScanner : public QThread
+{
+    Q_OBJECT
+public:
+    explicit ProcessScanner(QObject *parent = nullptr);
+
+protected:
+    void run() override;
+
+signals:
+    void processFound(qint64 pid, QString name);
+    void scanFinished();
+};
+
+#endif // PROCESSSCANNER_H

--- a/ui/mainwindow.ui
+++ b/ui/mainwindow.ui
@@ -1,0 +1,129 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MainWindow</class>
+ <widget class="QMainWindow" name="MainWindow">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>800</width>
+    <height>600</height>
+   </rect>
+  </property>
+  <widget class="QWidget" name="centralWidget">
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QTabWidget" name="tabWidget">
+      <widget class="QWidget" name="tabOverview">
+       <attribute name="title">
+        <string>Overview</string>
+       </attribute>
+      </widget>
+      <widget class="QWidget" name="tabFileScan">
+       <attribute name="title">
+        <string>File Scan</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayoutFile">
+        <item>
+         <widget class="QPushButton" name="scanFilesButton">
+          <property name="text">
+           <string>Сканировать файлы</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QProgressBar" name="fileProgressBar"/>
+        </item>
+        <item>
+         <widget class="QPushButton" name="cancelFileScanButton">
+          <property name="text">
+           <string>Отмена</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTableWidget" name="tableFiles">
+          <column>
+           <property name="text">
+            <string>Путь</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Название чита</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tabProcessScan">
+       <attribute name="title">
+        <string>Process Scan</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayoutProcess">
+        <item>
+         <widget class="QPushButton" name="scanProcessesButton">
+          <property name="text">
+           <string>Сканировать процессы</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTableWidget" name="tableProcesses">
+          <column>
+           <property name="text">
+            <string>PID</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Имя процесса</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tabMemoryScan">
+       <attribute name="title">
+        <string>Memory Scan</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayoutMemory">
+        <item>
+         <widget class="QPushButton" name="scanMemoryButton">
+          <property name="text">
+           <string>Сканировать память</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QTableWidget" name="tableMemory">
+          <column>
+           <property name="text">
+            <string>Адрес</string>
+           </property>
+          </column>
+          <column>
+           <property name="text">
+            <string>Название чита</string>
+           </property>
+          </column>
+         </widget>
+        </item>
+       </layout>
+      </widget>
+      <widget class="QWidget" name="tabSettings">
+       <attribute name="title">
+        <string>Settings</string>
+       </attribute>
+       <layout class="QVBoxLayout" name="verticalLayoutSettings"/>
+      </widget>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
## Summary
- expand signatures database with a memory section
- add build.bat for Visual Studio builds
- implement memory scanner using ReadProcessMemory
- hook up memory scanning in the main window
- allow canceling file scans
- document build instructions

## Testing
- `cmake -S . -B build` *(fails: could not find Qt6 package)*

------
https://chatgpt.com/codex/tasks/task_e_68515d4360b8832e80aedb76d3651cad